### PR TITLE
Add admin roles page

### DIFF
--- a/client/src/app/dashboard/roles/page.tsx
+++ b/client/src/app/dashboard/roles/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import * as React from 'react';
+import type { Metadata } from 'next';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { gql, useQuery } from '@apollo/client';
+
+import { config } from '@/config';
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export const metadata = { title: `Roles | Dashboard | ${config.site.name}` } satisfies Metadata;
+
+const GET_ROLES = gql`
+  query GetRoles {
+    roller {
+      id
+      rolAdi
+      izinler {
+        id
+        izinAdi
+      }
+    }
+  }
+`;
+
+export default function Page(): React.JSX.Element {
+  const { data, loading, error } = useQuery(GET_ROLES);
+
+  const renderContent = (): React.ReactNode => {
+    if (loading) {
+      return <Typography>Loading...</Typography>;
+    }
+
+    if (error) {
+      return <Typography color="error">{error.message}</Typography>;
+    }
+
+    if (!data?.roller?.length) {
+      return <Typography>No roles found.</Typography>;
+    }
+
+    return (
+      <Stack spacing={2}>
+        {data.roller.map((role: any) => (
+          <Stack key={role.id} spacing={0.5}>
+            <Typography variant="h6">{role.rolAdi}</Typography>
+            <Typography variant="body2">
+              {role.izinler && role.izinler.length > 0
+                ? role.izinler.map((p: any) => p.izinAdi).join(', ')
+                : 'No permissions'}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+    );
+  };
+
+  return (
+    <AdminGuard>
+      <Stack spacing={3}>
+        <Typography variant="h4">Roles</Typography>
+        {renderContent()}
+      </Stack>
+    </AdminGuard>
+  );
+}

--- a/client/src/components/auth/admin-guard.tsx
+++ b/client/src/components/auth/admin-guard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import Alert from '@mui/material/Alert';
+
+import { paths } from '@/paths';
+import { logger } from '@/lib/default-logger';
+import { useUser } from '@/hooks/use-user';
+
+export interface AdminGuardProps {
+  children: React.ReactNode;
+}
+
+export function AdminGuard({ children }: AdminGuardProps): React.JSX.Element | null {
+  const router = useRouter();
+  const { user, error, isLoading } = useUser();
+  const [isChecking, setIsChecking] = React.useState<boolean>(true);
+
+  const checkPermissions = async (): Promise<void> => {
+    if (isLoading) {
+      return;
+    }
+
+    if (error) {
+      setIsChecking(false);
+      return;
+    }
+
+    if (!user) {
+      logger.debug('[AdminGuard]: User is not logged in, redirecting to sign in');
+      router.replace(paths.auth.signIn);
+      return;
+    }
+
+    const isAdmin = user.roller?.some((role) => role.rolAdi === 'Yönetici');
+
+    if (!isAdmin) {
+      logger.debug('[AdminGuard]: User is not admin, redirecting to dashboard');
+      router.replace(paths.dashboard.overview);
+      return;
+    }
+
+    setIsChecking(false);
+  };
+
+  React.useEffect(() => {
+    checkPermissions().catch(() => {
+      // noop
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Expected
+  }, [user, error, isLoading]);
+
+  if (isChecking) {
+    return null;
+  }
+
+  if (error) {
+    return <Alert color="error">{error}</Alert>;
+  }
+
+  return <React.Fragment>{children}</React.Fragment>;
+}

--- a/client/src/components/dashboard/layout/config.ts
+++ b/client/src/components/dashboard/layout/config.ts
@@ -4,6 +4,7 @@ import { paths } from '@/paths';
 export const navItems = [
   { key: 'overview', title: 'Overview', href: paths.dashboard.overview, icon: 'chart-pie' },
   { key: 'customers', title: 'Customers', href: paths.dashboard.customers, icon: 'users' },
+  { key: 'roles', title: 'Roles', href: paths.dashboard.roles, icon: 'shield-check' },
   { key: 'integrations', title: 'Integrations', href: paths.dashboard.integrations, icon: 'plugs-connected' },
   { key: 'settings', title: 'Settings', href: paths.dashboard.settings, icon: 'gear-six' },
   { key: 'account', title: 'Account', href: paths.dashboard.account, icon: 'user' },

--- a/client/src/paths.ts
+++ b/client/src/paths.ts
@@ -6,6 +6,7 @@ export const paths = {
     account: '/dashboard/account',
     customers: '/dashboard/customers',
     integrations: '/dashboard/integrations',
+    roles: '/dashboard/roles',
     settings: '/dashboard/settings',
   },
   errors: { notFound: '/errors/not-found' },


### PR DESCRIPTION
## Summary
- define dashboard.roles path
- add roles nav entry
- create AdminGuard for admin-only pages
- add roles page with roles list

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684d622299a88328927e84041b246fcc