### PR TITLE
Align Fidan model with GraphQL schema

### DIFF
--- a/server/src/models/Fidan.js
+++ b/server/src/models/Fidan.js
@@ -1,29 +1,44 @@
 // server/src/models/Fidan.js
 const { Schema, model } = require('mongoose'); //
 
-const fidanSchema = new Schema({ //
-  name: { //
-    type: String, //
-    required: true, //
+const fidanSchema = new Schema({
+  ad: {
+    type: String,
+    required: true,
+    trim: true,
   },
-  parentId: { //
-    type: Schema.Types.ObjectId, //
-    ref: 'Fidan', //
-    default: null, //
+  aciklama: {
+    type: String,
+    default: '',
   },
-  musteriId: { // <-- EKLENEN KRİTİK ALAN //
-    type: String, //
-    required: true, //
+  stokMiktari: {
+    type: Number,
+    required: true,
+    min: 0,
   },
-  // fidanKodu: { // Kaldırıldı
-  //   type: String,
-  //   unique: true,
-  //   sparse: true,
-  // },
-  // satisFiyati: { // Kaldırıldı
-  //   type: Number,
-  // },
-}, { timestamps: true }); //
+  alisFiyati: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  satisFiyati: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  kategori: {
+    type: String,
+    default: '',
+  },
+  tedarikci: {
+    type: String,
+    default: '',
+  },
+  lokasyon: {
+    type: String,
+    default: '',
+  },
+}, { timestamps: true });
 
 const Fidan = model('Fidan', fidanSchema); //
 module.exports = Fidan;


### PR DESCRIPTION
## Summary
- update the Fidan mongoose model to match the GraphQL type
- include basic validation rules for the new fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d5ee1a8c88328aee5a484736f8980