### PR TITLE
Implement AdminGuard with tests

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,13 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/client/jest.setup.js
+++ b/client/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/client/src/app/dashboard/customers/page.tsx
+++ b/client/src/app/dashboard/customers/page.tsx
@@ -9,6 +9,7 @@ import { UploadIcon } from '@phosphor-icons/react/dist/ssr/Upload';
 import dayjs from 'dayjs';
 
 import { config } from '@/config';
+import { AdminGuard } from '@/components/auth/admin-guard';
 import { CustomersFilters } from '@/components/dashboard/customer/customers-filters';
 import { CustomersTable } from '@/components/dashboard/customer/customers-table';
 import type { Customer } from '@/components/dashboard/customer/customers-table';
@@ -116,10 +117,11 @@ export default function Page(): React.JSX.Element {
   const paginatedCustomers = applyPagination(customers, page, rowsPerPage);
 
   return (
-    <Stack spacing={3}>
-      <Stack direction="row" spacing={3}>
-        <Stack spacing={1} sx={{ flex: '1 1 auto' }}>
-          <Typography variant="h4">Customers</Typography>
+    <AdminGuard>
+      <Stack spacing={3}>
+        <Stack direction="row" spacing={3}>
+          <Stack spacing={1} sx={{ flex: '1 1 auto' }}>
+            <Typography variant="h4">Customers</Typography>
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
             <Button color="inherit" startIcon={<UploadIcon fontSize="var(--icon-fontSize-md)" />}>
               Import
@@ -142,7 +144,8 @@ export default function Page(): React.JSX.Element {
         rows={paginatedCustomers}
         rowsPerPage={rowsPerPage}
       />
-    </Stack>
+      </Stack>
+    </AdminGuard>
   );
 }
 

--- a/client/src/app/dashboard/integrations/page.tsx
+++ b/client/src/app/dashboard/integrations/page.tsx
@@ -12,6 +12,7 @@ import { UploadIcon } from '@phosphor-icons/react/dist/ssr/Upload';
 import dayjs from 'dayjs';
 
 import { config } from '@/config';
+import { AdminGuard } from '@/components/auth/admin-guard';
 import { IntegrationCard } from '@/components/dashboard/integrations/integrations-card';
 import type { Integration } from '@/components/dashboard/integrations/integrations-card';
 import { CompaniesFilters } from '@/components/dashboard/integrations/integrations-filters';
@@ -71,9 +72,10 @@ const integrations = [
 
 export default function Page(): React.JSX.Element {
   return (
-    <Stack spacing={3}>
-      <Stack direction="row" spacing={3}>
-        <Stack spacing={1} sx={{ flex: '1 1 auto' }}>
+    <AdminGuard>
+      <Stack spacing={3}>
+        <Stack direction="row" spacing={3}>
+          <Stack spacing={1} sx={{ flex: '1 1 auto' }}>
           <Typography variant="h4">Integrations</Typography>
           <Stack sx={{ alignItems: 'center' }} direction="row" spacing={1}>
             <Button color="inherit" startIcon={<UploadIcon fontSize="var(--icon-fontSize-md)" />}>
@@ -108,6 +110,7 @@ export default function Page(): React.JSX.Element {
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
         <Pagination count={3} size="small" />
       </Box>
-    </Stack>
+      </Stack>
+    </AdminGuard>
   );
 }

--- a/client/src/components/auth/__tests__/admin-guard.test.tsx
+++ b/client/src/components/auth/__tests__/admin-guard.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { AdminGuard } from '../admin-guard';
+import { UserContext, UserContextValue, Role, User } from '@/contexts/user-context';
+import { paths } from '@/paths';
+
+const mockReplace = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+const baseContext: UserContextValue = {
+  user: null,
+  error: null,
+  isLoading: false,
+  checkSession: jest.fn(),
+  signOut: jest.fn(),
+};
+
+function renderWithUser(user: User | null) {
+  return render(
+    <UserContext.Provider value={{ ...baseContext, user }}>
+      <AdminGuard>
+        <div>protected</div>
+      </AdminGuard>
+    </UserContext.Provider>
+  );
+}
+
+describe('AdminGuard', () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+  });
+
+  it('renders children for admin user', async () => {
+    const admin: User = {
+      id: '1',
+      kullaniciAdi: 'Admin',
+      email: 'a@a.a',
+      roller: [{ id: 'r1', rolAdi: 'Yönetici' } as Role],
+    };
+
+    renderWithUser(admin);
+    expect(await screen.findByText('protected')).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects non-admin user to dashboard', async () => {
+    const user: User = {
+      id: '2',
+      kullaniciAdi: 'User',
+      email: 'u@u.u',
+      roller: [{ id: 'r2', rolAdi: 'Kullanici' } as Role],
+    };
+
+    renderWithUser(user);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(paths.dashboard.overview);
+    });
+  });
+});

--- a/client/src/components/auth/admin-guard.tsx
+++ b/client/src/components/auth/admin-guard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import Alert from '@mui/material/Alert';
+
+import { paths } from '@/paths';
+import { logger } from '@/lib/default-logger';
+import { useUser } from '@/hooks/use-user';
+
+export interface AdminGuardProps {
+  children: React.ReactNode;
+}
+
+export function AdminGuard({ children }: AdminGuardProps): React.JSX.Element | null {
+  const router = useRouter();
+  const { user, error, isLoading } = useUser();
+  const [isChecking, setIsChecking] = React.useState<boolean>(true);
+
+  const checkPermissions = async (): Promise<void> => {
+    if (isLoading) {
+      return;
+    }
+
+    if (error) {
+      setIsChecking(false);
+      return;
+    }
+
+    if (!user) {
+      logger.debug('[AdminGuard]: User is not logged in, redirecting to sign in');
+      router.replace(paths.auth.signIn);
+      return;
+    }
+
+    const hasAdminRole = user.roller?.some((role) => role.rolAdi === 'Yönetici');
+
+    if (!hasAdminRole) {
+      logger.debug('[AdminGuard]: User is not admin, redirecting to dashboard');
+      router.replace(paths.dashboard.overview);
+      return;
+    }
+
+    setIsChecking(false);
+  };
+
+  React.useEffect(() => {
+    checkPermissions().catch(() => {
+      // noop
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Expected
+  }, [user, error, isLoading]);
+
+  if (isChecking) {
+    return null;
+  }
+
+  if (error) {
+    return <Alert color="error">{error}</Alert>;
+  }
+
+  return <React.Fragment>{children}</React.Fragment>;
+}


### PR DESCRIPTION
## Summary
- add `AdminGuard` component that restricts access to users with role `Yönetici`
- secure customer and integration pages with the new guard
- add Jest config and setup
- write unit tests for `AdminGuard`

## Testing
- `npx jest --runTestsByPath src/components/auth/__tests__/admin-guard.test.tsx` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_684d60a6a20883288f29969719b9d187